### PR TITLE
FireGraft: add hint for repair:

### DIFF
--- a/FireGraft/1161.fgd
+++ b/FireGraft/1161.fgd
@@ -471,6 +471,7 @@ UpgradeDat=0x1145c0
 75VarType=1
 76Change=0xeb1e
 76Entry=Abilities,Target,Repair,Remove race restriction
+76Hint=Must be used along with modifications to the Repair and Repair (Obscured) entries in orders.dat, check on Flag "Use Weapon Targeting"
 76Offset=0x67456
 76Size=2
 76Type=Code


### PR DESCRIPTION
Must be used along with modifications to the Repair and Repair (Obscured) entries in orders.dat, check on Flag "Use Weapon Targeting"
It took me a long time woundering why repair can't work with repair exe Edits enabled. No matter which version I swift to, 1.14, 1.15 or 1.16, when I try to use SVC (in my case, its Probe) to repair Protess Building, it keeps telling me can only repair Terran Targets.
Wrong address, maybe?
Finnaly I found the solution: check on Flag "Use Weapon Targeting" to the Repair and Repair (Obscured) entries in orders.dat along with Repair exe Edits.
So I think this hint should be add to repair, so that others may save a lot of time.